### PR TITLE
board settings are now stored on each board

### DIFF
--- a/src/js/components/BoardCanvas.js
+++ b/src/js/components/BoardCanvas.js
@@ -8,7 +8,8 @@ function BoardCanvas(props) {
   const gridColor = COLOR_GRID;
   const playerColor = [COLOR_X, COLOR_O];
   let { board, lastTickTime, width, height, padding } = props;
-  let { numRows, numCols, numPlayers, allMoves } = board;
+  let { numRows, numCols, numPlayers } = board.settings;
+  let { allMoves } = board;
   let cellWidth = (width-2*padding) / numCols;
   let cellHeight = (height-2*padding) / numRows;
   let gridThickness = cellWidth / 8;

--- a/src/js/components/SuperBoardCanvas.js
+++ b/src/js/components/SuperBoardCanvas.js
@@ -131,7 +131,7 @@ function SuperBoardCanvas(props) {
     if (lastDrawnMove === board.numMovesMade) {
       return;
     }
-    let { numRows, numCols, numPlayers } = board;
+    let { numRows, numCols, numPlayers } = board.settings;
     let cellWidth = width / numCols;
     let cellHeight = height / numRows;
     let pieceWidth = 0.5 * cellWidth;

--- a/src/js/game/upgrades.js
+++ b/src/js/game/upgrades.js
@@ -316,6 +316,7 @@ export const updateGameSettings = (mgs /*mutableGameState*/, upgrades, skipUpdat
     squareWin: 0,
     requireFull: false,
     allowErase: false,
+    numPlayers: 2,
   };
 
   // Super X Shop upgrades
@@ -331,6 +332,7 @@ export const updateGameSettings = (mgs /*mutableGameState*/, upgrades, skipUpdat
     lineWin: superBoardSize,
     squareWin: 0,
     requireFull: false,
+    numPlayers: 2,
   };
   mgs.winResetDelay = BASE_WIN_RESET_DELAY + upgrades[UPGRADE_TYPE.UPGRADE_SHOP_SUPER_O_WIN_RESET_DELAY];
   mgs.canPrestige = (upgrades[UPGRADE_TYPE.UPGRADE_SHOP_SUPER_O_UNLOCK_PRESTIGE] > 0);
@@ -378,9 +380,6 @@ export const updateGameSettings = (mgs /*mutableGameState*/, upgrades, skipUpdat
 
   if (Object.entries(newSuperBoardSettings).some(([prop,val])=>mgs.superBoardSettings[prop]!==val)) {
     Object.assign(mgs.superBoardSettings, newSuperBoardSettings);
-    if (!skipUpdateCache) {
-      recomputeSuperBoardSettingsCache(mgs.superBoardSettings);
-    }
   }
 };
 

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -123,7 +123,6 @@ function rootReducer(state, action) {
     }
 
     case ACTION_TYPE.ACTION_ADMIN_SET_STATE: {
-      console.log(action.payload);
       return action.payload;
     }
 


### PR DESCRIPTION
This fixes the issue where extendBoard used cached winning groups meant for a larger board. Cache now only applies to resetBoard, which means all rule changes only apply on board resets.